### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Build
+        run: npm run build
+        
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from 'vite';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
+import { fileURLToPath, URL } from 'node:url';
 
-export default defineConfig({
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/auto_flight/' : '/',
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),
@@ -31,4 +35,4 @@ export default defineConfig({
     port: 3000,
     open: true,
   },
-});
+}));


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automatic deployment to GitHub Pages
- Configure Vite for GitHub Pages deployment

## Changes
- Created `.github/workflows/deploy.yml` for automated deployment
- Updated `vite.config.ts` to set correct base path for production
- Fixed TypeScript errors with Node.js module imports
- Set repository name to `auto_flight`

## Test plan
- [ ] Verify the GitHub Actions workflow runs successfully after merge
- [ ] Check that the site is accessible at https://kurain.github.io/auto_flight/
- [ ] Confirm development server still works with `npm run dev`

🤖 Generated with [Claude Code](https://claude.ai/code)